### PR TITLE
Adds 'external_ref' column to OccurrencesInLine

### DIFF
--- a/icekit_events/admin.py
+++ b/icekit_events/admin.py
@@ -58,7 +58,7 @@ class EventRepeatGeneratorsInline(admin.TabularInline):
 class OccurrencesInline(admin.TabularInline):
     model = models.Occurrence
     form = admin_forms.BaseOccurrenceForm
-    fields = ('is_all_day', 'start', 'end', 'is_user_modified')
+    fields = ('is_all_day', 'start', 'end', 'is_user_modified', 'external_ref',)
     exclude = (
         'generator', 'is_generated',
         # is_hidden and is_cancelled aren't implemented yet,


### PR DESCRIPTION
PR to add an `external ref` column to the Occurrences Inline so that we can see at a glance the external reference IDs on a given event. It will be useful for troubleshooting integrations with external systems.