### PR TITLE
Add status string to Occurrence and editable field in OccurrencesInline

### DIFF
--- a/icekit_events/admin.py
+++ b/icekit_events/admin.py
@@ -58,7 +58,7 @@ class EventRepeatGeneratorsInline(admin.TabularInline):
 class OccurrencesInline(admin.TabularInline):
     model = models.Occurrence
     form = admin_forms.BaseOccurrenceForm
-    fields = ('is_all_day', 'start', 'end', 'is_user_modified', 'external_ref')
+    fields = ('is_all_day', 'start', 'end', 'is_user_modified', 'external_ref', 'status')
     exclude = (
         'generator', 'is_generated',
         # is_hidden and is_cancelled aren't implemented yet,

--- a/icekit_events/migrations/0012_occurrence_status.py
+++ b/icekit_events/migrations/0012_occurrence_status.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_events', '0011_auto_20161128_1049'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='occurrence',
+            name='status',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/icekit_events/models.py
+++ b/icekit_events/models.py
@@ -878,6 +878,11 @@ class Occurrence(AbstractBaseModel):
         blank=True, null=True,
     )
 
+    status = models.CharField(
+        max_length=255,
+        blank=True, null=True,
+    )
+
     # Start/end times as originally set by a generator, before user modifiction
     original_start = models.DateTimeField(
         blank=True, null=True, editable=False)


### PR DESCRIPTION
This is to add an editable string as a session status for each occurrence. This feature will allow automated 3rd party tools to switch out the status on an occurrence dynamically, but also allow an editor in the CMS to update a particular status if there needs to be alternative message for a particular occurrence. As a string field, this should give us the most flexibility for our particular needs. Happy to make adjustments if it's not 100% the direction you want to go with for icekit-events.