### PR TITLE
Add occurrence urls admin so that they're user editable from the admin.

### DIFF
--- a/icekit_events/admin.py
+++ b/icekit_events/admin.py
@@ -317,6 +317,10 @@ class RecurrenceRuleAdmin(admin.ModelAdmin):
         return JsonResponse(data)
 
 
+class OccurrenceUrlAdmin(admin.ModelAdmin):
+    pass
+
+
 class EventTypeAdmin(TitleSlugAdmin):
     list_display = TitleSlugAdmin.list_display + ('is_public',)
     list_filter = ('is_public',)
@@ -325,3 +329,4 @@ class EventTypeAdmin(TitleSlugAdmin):
 admin.site.register(models.EventBase, EventAdmin)
 admin.site.register(models.EventType, EventTypeAdmin)
 admin.site.register(models.RecurrenceRule, RecurrenceRuleAdmin)
+admin.site.register(models.OccurrenceUrlPrefix, OccurrenceUrlAdmin)

--- a/icekit_events/migrations/0013_auto_20161201_1518.py
+++ b/icekit_events/migrations/0013_auto_20161201_1518.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import timezone.timezone
+import icekit.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_events', '0012_occurrence_status'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OccurrenceUrlPrefix',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('created', models.DateTimeField(db_index=True, default=timezone.timezone.now, editable=False)),
+                ('modified', models.DateTimeField(db_index=True, default=timezone.timezone.now, editable=False)),
+                ('name', models.TextField(unique=True, blank=True, help_text=b'Name of the URL to use for occurrences.')),
+                ('url', models.URLField(help_text=b'URL to use for each occurrence for an event.')),
+            ],
+            options={
+                'abstract': False,
+                'get_latest_by': 'pk',
+                'ordering': ('-id',),
+            },
+        ),
+        migrations.AddField(
+            model_name='eventbase',
+            name='occurrence_append_external_ref',
+            field=models.BooleanField(default=True, help_text='Append occurrence external_ref to each occurrence URL.'),
+        ),
+        migrations.AddField(
+            model_name='eventbase',
+            name='occurrence_url',
+            field=icekit.fields.ICEkitURLField(max_length=300, help_text='The URL to use for each occurrence.', null=True, verbose_name='Occurrence URL', blank=True),
+        ),
+    ]

--- a/icekit_events/models.py
+++ b/icekit_events/models.py
@@ -195,6 +195,7 @@ class RecurrenceRule(AbstractBaseModel):
     def __str__(self):
         return self.description
 
+
 class EventType(TitleSlugMixin):
     is_public = models.BooleanField(
         "Show to public?",
@@ -204,6 +205,22 @@ class EventType(TitleSlugMixin):
                   "Non-public types are used to indicate special behaviour, "
                   "such as education or members events."
     )
+
+
+@encoding.python_2_unicode_compatible
+class OccurrenceUrlPrefix(AbstractBaseModel):
+    name = models.TextField(
+        help_text="Name of the URL to use for occurrences.",
+        unique=True,
+        blank=True
+    )
+    url = models.URLField(
+        help_text="URL to use for each occurrence for an event."
+    )
+
+    def __str__(self):
+        return self.name
+
 
 @encoding.python_2_unicode_compatible
 class EventBase(PolymorphicModel, AbstractBaseModel, PublishingModel,
@@ -294,6 +311,17 @@ class EventBase(PolymorphicModel, AbstractBaseModel, PublishingModel,
         null=True,
         help_text=_('The URL where visitors can arrange to attend an event'
                     ' by purchasing tickets or RSVPing.')
+    )
+    occurrence_url = models.CharField(_("Occurrence URL"),
+        max_length=255,
+        choices=[(o_url.url, o_url.name) for o_url in OccurrenceUrlPrefix.objects.all()],
+        blank=True,
+        null=True,
+        help_text=_('The URL to use for each occurrence.')
+    )
+    occurrence_append_external_ref = models.BooleanField(
+        default=True,
+        help_text=_("Append occurrence external_ref to each occurrence URL.")
     )
 
     class Meta:

--- a/icekit_events/page_types/eventlistingfordate/migrations/0005_auto_20161201_1518.py
+++ b/icekit_events/page_types/eventlistingfordate/migrations/0005_auto_20161201_1518.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('eventlistingfordate', '0004_auto_20161115_1118'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='eventlistingpage',
+            name='hero_image',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, related_name='+', blank=True, help_text=b'The hero image for this content.', to='icekit_plugins_image.Image', null=True),
+        ),
+    ]


### PR DESCRIPTION
@cogat -- this PR is to add a couple of fields to events, to store a string for the Occurrence URL prefix, and a boolean for whether or not to append the external_ref to the URL.

I thought this might be best in icekit-events, so that Occurrence URL prefixes are editable as global settings in the Admin. That way there's a user friendly drop-down for the field on an event page, with URLs / options that can be updated separately in the Occurrence URL Admin. Then in `admin.py` over in ACMI/events, we can add in the additional fields.

I'm still having difficulty running the tests for icekit-events (tox) -- I keep getting a `django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet` error. But wanted to share where I'm at.

With this, we could construct URLs for an individual occurrence in a view with something like:

```
if event.occurrence_append_external_ref:
    constructed_url = event.occurrence_url + occurrence.external_ref
```
