### PR TITLE
Add `EventContentListingPlugin`

### DIFF
--- a/icekit_events/plugins/event_content_listing/__init__.py
+++ b/icekit_events/plugins/event_content_listing/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = '%s.apps.AppConfig' % __name__

--- a/icekit_events/plugins/event_content_listing/abstract_models.py
+++ b/icekit_events/plugins/event_content_listing/abstract_models.py
@@ -1,6 +1,13 @@
+from datetime import timedelta
+
+from django.db import models
+from django.db.models import Q
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
+from timezone import timezone as djtz  # django-timezone
+
+from icekit_events.models import EventType
 from icekit.plugins.content_listing.abstract_models import \
     AbstractContentListingItem
 
@@ -10,6 +17,34 @@ class AbstractEventContentListingItem(AbstractContentListingItem):
     """
     An embedded listing of event content items.
     """
+    limit_to_types = models.ManyToManyField(
+        EventType,
+        help_text="Leave empty to show all events.",
+        blank=True,
+        db_table="ik_event_listing_types",
+    )
+    from_date = models.DateTimeField(
+        blank=True, null=True,
+        help_text="Only show events with occurrences that end after this"
+                  " date and time.",
+    )
+    to_date = models.DateTimeField(
+        blank=True, null=True,
+        help_text="Only show events with occurrences that start before this"
+                  " date and time.",
+    )
+    from_days_ago = models.IntegerField(
+        blank=True, null=True,
+        help_text="Only show events with occurrences after this number of"
+                  " days into the past. Set this to zero to show only events"
+                  " with future occurrences.",
+    )
+    to_days_ahead = models.IntegerField(
+        blank=True, null=True,
+        help_text="Only show events with occurrences before this number of"
+                  " days into the future. Set this to zero to show only events"
+                  " with past occurrences.",
+    )
 
     class Meta:
         abstract = True
@@ -19,4 +54,26 @@ class AbstractEventContentListingItem(AbstractContentListingItem):
         return 'Event Content Listing of %s' % self.content_type
 
     def get_items(self):
-        return super(AbstractEventContentListingItem, self).get_items()
+        qs = super(AbstractEventContentListingItem, self).get_items(
+            apply_limit=False)
+        if self.limit_to_types.count():
+            types = self.limit_to_types.all()
+            qs = qs.filter(
+                Q(primary_type__in=types) |
+                Q(secondary_types__in=types)
+            )
+        # Apply `from_date` and `to_date` limits
+        qs = qs.overlapping(self.from_date, self.to_date)
+        # Apply `from_days_ago` and `to_days_ahead` limits
+        today = djtz.now().date()
+        from_date = to_date = None
+        if self.from_days_ago is not None:
+            from_date = today - timedelta(days=self.from_days_ago)
+        if self.to_days_ahead is not None:
+            to_date = today + timedelta(days=self.to_days_ahead)
+        qs = qs.overlapping(from_date, to_date)
+        # Apply a sensible default ordering
+        qs = qs.order_by_first_occurrence()
+        if self.limit:
+            qs = qs[:self.limit]
+        return qs

--- a/icekit_events/plugins/event_content_listing/abstract_models.py
+++ b/icekit_events/plugins/event_content_listing/abstract_models.py
@@ -1,0 +1,22 @@
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import ugettext_lazy as _
+
+from icekit.plugins.content_listing.abstract_models import \
+    AbstractContentListingItem
+
+
+@python_2_unicode_compatible
+class AbstractEventContentListingItem(AbstractContentListingItem):
+    """
+    An embedded listing of event content items.
+    """
+
+    class Meta:
+        abstract = True
+        verbose_name = _('Event Content Listing')
+
+    def __str__(self):
+        return 'Event Content Listing of %s' % self.content_type
+
+    def get_items(self):
+        return super(AbstractEventContentListingItem, self).get_items()

--- a/icekit_events/plugins/event_content_listing/apps.py
+++ b/icekit_events/plugins/event_content_listing/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AppConfig(AppConfig):
+    name = '.'.join(__name__.split('.')[:-1])
+    label = "ik_event_listing"
+    verbose_name = "Event Content Listing"

--- a/icekit_events/plugins/event_content_listing/content_plugins.py
+++ b/icekit_events/plugins/event_content_listing/content_plugins.py
@@ -1,0 +1,17 @@
+"""
+Definition of the plugin.
+"""
+from django.utils.translation import ugettext_lazy as _
+
+from fluent_contents.extensions import ContentPlugin, plugin_pool
+
+from . import forms, models
+
+
+@plugin_pool.register
+class EventContentListingPlugin(ContentPlugin):
+    model = models.EventContentListingItem
+    category = _('Assets')
+    render_template = 'icekit_events/plugins/event_content_listing/default.html'
+    form = forms.EventContentListingAdminForm
+    cache_output = False

--- a/icekit_events/plugins/event_content_listing/forms.py
+++ b/icekit_events/plugins/event_content_listing/forms.py
@@ -6,6 +6,10 @@ from .models import EventContentListingItem
 
 
 class EventContentListingAdminForm(ContentListingAdminForm):
+    # TODO Improve admin experience:
+    # - horizontal filter for `limit_to_types` choice
+    # - verbose_name for Content Type
+    # - default (required) value for No Items Message.
 
     class Meta:
         model = EventContentListingItem

--- a/icekit_events/plugins/event_content_listing/forms.py
+++ b/icekit_events/plugins/event_content_listing/forms.py
@@ -1,0 +1,21 @@
+from icekit.plugins.content_listing.forms import ContentListingAdminForm
+
+from icekit_events.models import EventBase
+
+from .models import EventContentListingItem
+
+
+class EventContentListingAdminForm(ContentListingAdminForm):
+
+    class Meta:
+        model = EventContentListingItem
+        fields = '__all__'
+
+    def filter_content_types(self, content_type_qs):
+        """ Filter the content types selectable to only event subclasses """
+        valid_ct_ids = []
+        for ct in content_type_qs:
+            model = ct.model_class()
+            if model and issubclass(model, EventBase):
+                valid_ct_ids.append(ct.id)
+        return content_type_qs.filter(pk__in=valid_ct_ids)

--- a/icekit_events/plugins/event_content_listing/migrations/0001_initial.py
+++ b/icekit_events/plugins/event_content_listing/migrations/0001_initial.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fluent_contents', '0001_initial'),
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EventContentListingItem',
+            fields=[
+                ('contentitem_ptr', models.OneToOneField(serialize=False, primary_key=True, to='fluent_contents.ContentItem', parent_link=True, auto_created=True)),
+                ('limit', models.IntegerField(null=True, help_text=b'How many items to show? No limit is applied if this field is not set', blank=True)),
+                ('content_type', models.ForeignKey(help_text=b'Content type of items to show in a listing', to='contenttypes.ContentType')),
+            ],
+            options={
+                'db_table': 'contentitem_ik_event_listing_eventcontentlistingitem',
+                'abstract': False,
+                'verbose_name': 'Event Content Listing',
+            },
+            bases=('fluent_contents.contentitem',),
+        ),
+    ]

--- a/icekit_events/plugins/event_content_listing/migrations/0002_auto_20170222_1136.py
+++ b/icekit_events/plugins/event_content_listing/migrations/0002_auto_20170222_1136.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('icekit_events', '0016_auto_20161208_0030'),
+        ('ik_event_listing', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='eventcontentlistingitem',
+            name='from_date',
+            field=models.DateTimeField(help_text=b'Only show events with occurrences that end after this date and time.', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='eventcontentlistingitem',
+            name='from_days_ago',
+            field=models.IntegerField(help_text=b'Only show events with occurrences after this number of days into the past. Set this to zero to show only events with future occurrences.', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='eventcontentlistingitem',
+            name='limit_to_types',
+            field=models.ManyToManyField(help_text=b'Leave empty to show all events.', to='icekit_events.EventType', db_table=b'ik_event_listing_types', blank=True),
+        ),
+        migrations.AddField(
+            model_name='eventcontentlistingitem',
+            name='to_date',
+            field=models.DateTimeField(help_text=b'Only show events with occurrences that start before this date and time.', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='eventcontentlistingitem',
+            name='to_days_ahead',
+            field=models.IntegerField(help_text=b'Only show events with occurrences before this number of days into the future. Set this to zero to show only events with past occurrences.', null=True, blank=True),
+        ),
+    ]

--- a/icekit_events/plugins/event_content_listing/migrations/0003_eventcontentlistingitem_no_items_message.py
+++ b/icekit_events/plugins/event_content_listing/migrations/0003_eventcontentlistingitem_no_items_message.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ik_event_listing', '0002_auto_20170222_1136'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='eventcontentlistingitem',
+            name='no_items_message',
+            field=models.CharField(blank=True, help_text=b'Message to show if there are not items in listing.', null=True, max_length=255),
+        ),
+    ]

--- a/icekit_events/plugins/event_content_listing/models.py
+++ b/icekit_events/plugins/event_content_listing/models.py
@@ -1,0 +1,8 @@
+from .abstract_models import AbstractEventContentListingItem
+
+
+class EventContentListingItem(AbstractEventContentListingItem):
+    """
+    An embedded listing of event content items.
+    """
+    pass

--- a/icekit_events/plugins/event_content_listing/templates/icekit_events/plugins/event_content_listing/_event.html
+++ b/icekit_events/plugins/event_content_listing/templates/icekit_events/plugins/event_content_listing/_event.html
@@ -1,0 +1,4 @@
+<li><a href="{{ event.get_absolute_url }}">
+	{{ event.title|safe }}
+</a></li>
+

--- a/icekit_events/plugins/event_content_listing/templates/icekit_events/plugins/event_content_listing/default.html
+++ b/icekit_events/plugins/event_content_listing/templates/icekit_events/plugins/event_content_listing/default.html
@@ -2,8 +2,7 @@
 	{% for event in instance.get_items %}
 		{% include "icekit_events/plugins/event_content_listing/_event.html" %}
 	{% empty %}
-			<li>There are no items to show on this page</li>
-		{{ instance.get_default_embed }}
+		<li>{{ instance.no_items_message|default:"There are no items to show" }}</li>
 	{% endfor %}
 </div>
 

--- a/icekit_events/plugins/event_content_listing/templates/icekit_events/plugins/event_content_listing/default.html
+++ b/icekit_events/plugins/event_content_listing/templates/icekit_events/plugins/event_content_listing/default.html
@@ -1,0 +1,9 @@
+<div class="content-listing">
+	{% for event in instance.get_items %}
+		{% include "icekit_events/plugins/event_content_listing/_event.html" %}
+	{% empty %}
+			<li>There are no items to show on this page</li>
+		{{ instance.get_default_embed }}
+	{% endfor %}
+</div>
+

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         'Django<1.9',
-        'django-dynamic-fixture',
         # TODO Specific version of django-dynamic-fixture is necessary to avoid
         # AttributeError: can't set attribute` failures on polymorphic models.
         # See https://github.com/paulocheque/django-dynamic-fixture/pull/59

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,10 @@ setuptools.setup(
     install_requires=[
         'Django<1.9',
         'django-dynamic-fixture',
+        # TODO Specific version of django-dynamic-fixture is necessary to avoid
+        # AttributeError: can't set attribute` failures on polymorphic models.
+        # See https://github.com/paulocheque/django-dynamic-fixture/pull/59
+        'django-dynamic-fixture==1.9.0+0.caeb3427399edd3b0d589516993c7da55e0de560.ixc',
         'django-icekit',
         'django-polymorphic',
         'django-polymorphic-tree',


### PR DESCRIPTION
Add a new `EventContentListingPlugin` – based on [ICEkit's new `ContentListingPlugin`](https://github.com/ic-labs/django-icekit/pull/196) – that allows CMS admins to add listings of Events (really Occurrences) to pages as content blocks.

The implementation offers some reasonably sophisticated controls over which events/occurrences will be listed including: the event's primary/secondary types, from/to datetime ranges for occurrences, and from/to ranges based on a number of days into the past or future.

This plugin is intended to be a flexible solution for issues like ACMI's need to display an event listing on real pages, as opposed to simplified listing views, so the admins can modify features of the page as they can for pages in general.